### PR TITLE
debug mkdocs indent issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,17 +1,13 @@
 ---
 name: CI
-
 on:
   push:
     branches: [main]
-    tags:
-      - v*
+    tags: [v*]
   pull_request:
-
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
@@ -19,29 +15,24 @@ jobs:
         with:
           python-version: '3.10'
       - uses: pre-commit/action@v2.0.0
-
   tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.7, '3.10']
         os: [ubuntu-latest, windows-latest]
-
     steps:
       - uses: actions/checkout@v2
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-
       - name: Installation (deps and package)
         # we install with flit --pth-file,
         # so that coverage will be recorded for the module
         run: |
           pip install flit
           flit install --deps=production --extras=test --pth-file
-
       - name: Run pytest
         run: |
           pytest --cov=mdformat_admon --cov-report=xml --cov-report=term-missing
@@ -54,26 +45,21 @@ jobs:
       #     flags: pytests
       #     file: ./coverage.xml
       #     fail_ci_if_error: false
-
   pre-commit-hook:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
           python-version: '3.10'
-
       - name: Installation (deps and package)
         run: |
           pip install pre-commit
           pip install .
-
       - name: run pre-commit with plugin
         run: |
           pre-commit run --config .pre-commit-test.yaml --all-files --verbose --show-diff-on-failure
-
   publish:
     name: Publish to PyPi
     needs: [pre-commit, tests, pre-commit-hook]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,15 +27,15 @@ repos:
       - id: trailing-whitespace
         exclude: tests/fixtures.*\.md
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.9.0
+    rev: v1.10.0
     hooks:
       - id: python-check-blanket-noqa
   - repo: https://github.com/timothycrosley/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.3.0
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
@@ -56,7 +56,7 @@ repos:
         exclude: tests/.+\.md
         args: [--wrap=no]
   - repo: https://github.com/lyz-code/yamlfix/
-    rev: 1.1.1
+    rev: 1.9.0
     hooks:
       - id: yamlfix
         types_or: []

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -51,8 +51,7 @@ repos:
     rev: 0.7.16
     hooks:
       - id: mdformat
-        additional_dependencies:
-          - mdformat-mkdocs[recommended]
+        additional_dependencies: ['mdformat-mkdocs[recommended]']
         exclude: tests/.+\.md
         args: [--wrap=no]
   - repo: https://github.com/lyz-code/yamlfix/

--- a/mdformat_mkdocs/plugin.py
+++ b/mdformat_mkdocs/plugin.py
@@ -15,7 +15,7 @@ def update_mdit(mdit: MarkdownIt) -> None:
     ...
 
 
-_RE_INDENT = re.compile(r"(?P<indent>\s*)(?P<content>.*)")
+_RE_INDENT = re.compile(r"(?P<indent>\s*)(?P<content>[^\s]?.*)")
 """Match `indent` and `content` against line`."""
 
 _RE_LIST_ITEM = re.compile(r"(?P<bullet>[\-\*\d\.]+)\s+(?P<item>.+)")
@@ -24,7 +24,7 @@ _RE_LIST_ITEM = re.compile(r"(?P<bullet>[\-\*\d\.]+)\s+(?P<item>.+)")
 
 def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> str:
     """Post-processor to normalize lists."""
-    eol = "\n"  # PLANNED: Does this need to support carriage returns?
+    eol = "\n"
     indent = " " * _MKDOCS_INDENT_COUNT
 
     rendered = ""
@@ -54,7 +54,7 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
                 raise NotImplementedError(f"Error in indentation of: `{line}`")
         else:
             indent_counter = 0
-        last_indent = match["indent"]
+        last_indent = this_indent
         new_indent = indent * indent_counter
         rendered += f"{new_indent}{new_line.strip()}{eol}"
     return rendered.rstrip()

--- a/mdformat_mkdocs/plugin.py
+++ b/mdformat_mkdocs/plugin.py
@@ -1,12 +1,13 @@
 import re
+from os import environ
 from typing import Dict, Mapping
 
 from markdown_it import MarkdownIt
 from mdformat.renderer import RenderContext, RenderTreeNode
 from mdformat.renderer.typing import Postprocess, Render
 
-_MKDOCS_INDENT_COUNT = 4
-"""Use 4-spaces for mkdocs."""
+_MKDOCS_INDENT_COUNT = int(environ.get("MDFORMAT_MKDOCS_INDENT_COUNT", "2"))
+"""Use 2-spaces for mkdocs or whichever environment variable is configured."""
 
 
 def update_mdit(mdit: MarkdownIt) -> None:

--- a/mdformat_mkdocs/plugin.py
+++ b/mdformat_mkdocs/plugin.py
@@ -1,13 +1,12 @@
 import re
-from os import environ
 from typing import Dict, Mapping
 
 from markdown_it import MarkdownIt
 from mdformat.renderer import RenderContext, RenderTreeNode
 from mdformat.renderer.typing import Postprocess, Render
 
-_MKDOCS_INDENT_COUNT = int(environ.get("MDFORMAT_MKDOCS_INDENT_COUNT", "2"))
-"""Use 2-spaces for mkdocs or whichever environment variable is configured."""
+_MKDOCS_INDENT_COUNT = 4
+"""Use 4-spaces for mkdocs."""
 
 
 def update_mdit(mdit: MarkdownIt) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -10,22 +10,32 @@ skip_missing_interpreters = False
 [testenv:py{310}]
 extras = test
 commands = pytest {posargs} --ff -vv
+setenv =
+    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{310}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_mkdocs {posargs}
+setenv =
+    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{37}-recommended]
 extras = recommended,test
 commands = pytest {posargs} --ff -vv
+setenv =
+    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{310}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs:--all-files}
+setenv =
+    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{37,310}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
+setenv =
+    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [flake8]
 max-line-length = 88

--- a/tox.ini
+++ b/tox.ini
@@ -10,32 +10,22 @@ skip_missing_interpreters = False
 [testenv:py{310}]
 extras = test
 commands = pytest {posargs} --ff -vv
-setenv =
-    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{310}-cov]
 extras = test
 commands = pytest --cov={envsitepackagesdir}/mdformat_mkdocs {posargs}
-setenv =
-    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{37}-recommended]
 extras = recommended,test
 commands = pytest {posargs} --ff -vv
-setenv =
-    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{310}-pre-commit]
 extras = dev
 commands = pre-commit run {posargs:--all-files}
-setenv =
-    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [testenv:py{37,310}-hook]
 extras = dev
 commands = pre-commit run --config .pre-commit-test.yaml {posargs:--all-files --verbose --show-diff-on-failure}
-setenv =
-    MDFORMAT_MKDOCS_INDENT_COUNT = 4
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Root cause was https://pypi.org/project/mdx-truly-sane-lists, which changes the default to 2 spaces

Fixed in: https://github.com/KyleKing/recipes/commit/c45e2e1ee66243e921021085609490338abed1f7