### PR TITLE
fix: resolve semantic errors

### DIFF
--- a/.pre-commit-test.yaml
+++ b/.pre-commit-test.yaml
@@ -13,7 +13,7 @@ repos:
       - id: mdformat-with-semantic-arg
         name: mdformat-with-semantic-arg
         entry: mdformat
-        args: [--align-semantic-breaks-in-numbered-lists]
-        files: tests/pre-commit-test-align_semantic_breaks_in_numbered_lists.md
+        args: [--align-semantic-breaks-in-lists]
+        files: tests/pre-commit-test-align_semantic_breaks_in_lists.md
         types: [markdown]
         language: system

--- a/README.md
+++ b/README.md
@@ -51,19 +51,19 @@ pipx inject mdformat mdformat-mkdocs
 
 ## CLI Options
 
-`mdformat-mkdocs` adds the CLI argument `--align-semantic-breaks-in-numbered-lists` to optionally align line breaks in numbered lists to 3-spaces. If not specified, the default of 4-indents is followed universally.
+`mdformat-mkdocs` adds the CLI argument `--align-semantic-breaks-in-lists` to optionally align line breaks in numbered lists to 3-spaces. If not specified, the default of 4-indents is followed universally.
 
 ```txt
 # with: mdformat
 1. Semantic line feed where the following line is
     three spaces deep
 
-# vs. with: mdformat --align-semantic-breaks-in-numbered-lists
+# vs. with: mdformat --align-semantic-breaks-in-lists
 1. Semantic line feed where the following line is
    three spaces deep
 ```
 
-Note: the `align-semantic-breaks-in-numbered-lists` setting is not supported in the configuration file yet (https://github.com/executablebooks/mdformat/issues/378)
+Note: the `align-semantic-breaks-in-lists` setting is not supported in the configuration file yet (https://github.com/executablebooks/mdformat/issues/378)
 
 ## Caveats
 

--- a/mdformat_mkdocs/__init__.py
+++ b/mdformat_mkdocs/__init__.py
@@ -1,6 +1,6 @@
 """An mdformat plugin for mkdocs."""
 
-__version__ = "1.0.2"
+__version__ = "1.0.3"
 
 from .plugin import (  # noqa: F401
     POSTPROCESSORS,

--- a/mkdocs-demo/docs/README.md
+++ b/mkdocs-demo/docs/README.md
@@ -15,7 +15,7 @@ See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
        three.
 
 1. Here indent width is
-   five (three). It needs to be so, because
+   five (three). The following indent needs to be four (but it is 3 with semantic change).
 
    Otherwise this next paragraph doesn't belong in the same list item.
 
@@ -30,6 +30,24 @@ See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
         three (four).
 
 1. Here indent width is
-    five (four). It needs to be so, because
+    five (four). The following indent needs to be four.
 
     Otherwise this next paragraph doesn't belong in the same list item.
+
+---
+
+### With proposed change for bullets
+
+1. Line
+   semantic line 1 (3 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)
+
+---
+
+### With proposed change for bullets nested in a numbered list
+
+- Line
+  semantic line 1 (2 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)

--- a/tests/fixtures-semantic-indent.md
+++ b/tests/fixtures-semantic-indent.md
@@ -224,6 +224,34 @@ Nested semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
 .
 
 
+Bulleted semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
+.
+- Line
+  semantic line 1 (2 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)
+.
+- Line
+  semantic line 1 (2 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)
+.
+
+
+Nested semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
+.
+- Line
+    semantic line 1 (2 spaces deep)
+    1. Bullet (4 spaces deep)
+        semantic line 2 (7 spaces deep)
+.
+- Line
+  semantic line 1 (2 spaces deep)
+    1. Bullet (4 spaces deep)
+       semantic line 2 (7 spaces deep)
+.
+
+
 Table
 .
 | Label          |   Rating | Comment              |

--- a/tests/fixtures-semantic-indent.md
+++ b/tests/fixtures-semantic-indent.md
@@ -140,7 +140,7 @@ List with (what should be converted to a) code block
 .
 - item 1
 
-    code block
+  code block
 .
 
 List with explicit code block (that should keep indentation)
@@ -153,9 +153,9 @@ List with explicit code block (that should keep indentation)
 .
 - item 1
 
-    ```txt
-    code block
-    ```
+  ```txt
+  code block
+  ```
 .
 
 

--- a/tests/fixtures-semantic-indent.md
+++ b/tests/fixtures-semantic-indent.md
@@ -173,15 +173,15 @@ Hanging List (https://github.com/executablebooks/mdformat/issues/371 and https:/
      Otherwise this next paragraph doesn't belong in the same list item.
 .
 1. Here indent width is
-    three.
+   three.
 
     1. Here indent width is
-        three.
+       three.
 
 1. Here indent width is
-    five. It needs to be so, because
+   five. It needs to be so, because
 
-    Otherwise this next paragraph doesn't belong in the same list item.
+   Otherwise this next paragraph doesn't belong in the same list item.
 .
 
 
@@ -198,11 +198,11 @@ Code block in semantic indent (https://github.com/KyleKing/mdformat-mkdocs/issue
 1. Item 3
 .
 1. Item 1
-    with a semantic line feed
+   with a semantic line feed
 
-    ```bash
-    echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
-    ```
+   ```bash
+   echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
+   ```
 
 1. Item 2
 
@@ -218,9 +218,9 @@ Nested semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
       semantic line 2 (6 spaces deep)
 .
 1. Line
-    semantic line 1 (3 spaces deep)
+   semantic line 1 (3 spaces deep)
     - Bullet (4 spaces deep)
-        semantic line 2 (6 spaces deep)
+      semantic line 2 (6 spaces deep)
 .
 
 

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -232,9 +232,9 @@ Bulleted semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
       semantic line 2 (6 spaces deep)
 .
 - Line
-  semantic line 1 (2 spaces deep)
+    semantic line 1 (2 spaces deep)
     - Bullet (4 spaces deep)
-      semantic line 2 (6 spaces deep)
+        semantic line 2 (6 spaces deep)
 .
 
 

--- a/tests/fixtures.md
+++ b/tests/fixtures.md
@@ -224,6 +224,34 @@ Nested semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
 .
 
 
+Bulleted semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
+.
+- Line
+  semantic line 1 (2 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)
+.
+- Line
+  semantic line 1 (2 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)
+.
+
+
+Nested semantic lines (https://github.com/KyleKing/mdformat-mkdocs/issues/7)
+.
+- Line
+    semantic line 1 (2 spaces deep)
+    1. Bullet (4 spaces deep)
+        semantic line 2 (7 spaces deep)
+.
+- Line
+    semantic line 1 (2 spaces deep)
+    1. Bullet (4 spaces deep)
+        semantic line 2 (7 spaces deep)
+.
+
+
 Table
 .
 | Label          |   Rating | Comment              |

--- a/tests/pre-commit-test-align_semantic_breaks_in_lists.md
+++ b/tests/pre-commit-test-align_semantic_breaks_in_lists.md
@@ -1,4 +1,4 @@
-# Testing `--align-semantic-breaks-in-numbered-lists`
+# Testing `--align-semantic-breaks-in-lists`
 
 ## Semantic Line Indents
 

--- a/tests/pre-commit-test-align_semantic_breaks_in_numbered_lists.md
+++ b/tests/pre-commit-test-align_semantic_breaks_in_numbered_lists.md
@@ -1,4 +1,6 @@
-# Semantic Line Indents
+# Testing `--align-semantic-breaks-in-numbered-lists`
+
+## Semantic Line Indents
 
 See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
 
@@ -12,3 +14,27 @@ See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
    five (three). It needs to be so, because
 
    Otherwise this next paragraph doesn't belong in the same list item.
+
+## Code block in semantic indent
+
+From: https://github.com/KyleKing/mdformat-mkdocs/issues/6
+
+1. Item 1
+   with a semantic line feed
+
+   ```bash
+   echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
+   ```
+
+1. Item 2
+
+1. Item 3
+
+## Nested semantic lines
+
+From: https://github.com/KyleKing/mdformat-mkdocs/issues/7
+
+1. Line
+   semantic line 1 (3 spaces deep)
+    - Bullet (4 spaces deep)
+      semantic line 2 (6 spaces deep)

--- a/tests/test_align_semantic_breaks_in_lists.py
+++ b/tests/test_align_semantic_breaks_in_lists.py
@@ -11,10 +11,10 @@ fixtures = read_fixture_file(FIXTURE_PATH)
 @pytest.mark.parametrize(
     "line,title,text,expected", fixtures, ids=[f[1] for f in fixtures]
 )
-def test_fixtures(line, title, text, expected):
+def test_align_semantic_breaks_in_lists(line, title, text, expected):
     output = mdformat.text(
         text,
-        options={"align_semantic_breaks_in_numbered_lists": True},
+        options={"align_semantic_breaks_in_lists": True},
         extensions={"mkdocs"},
     )
     assert output.rstrip() == expected.rstrip()

--- a/tests/test_align_semantic_breaks_in_numbered_lists.py
+++ b/tests/test_align_semantic_breaks_in_numbered_lists.py
@@ -1,37 +1,20 @@
+from pathlib import Path
+
+from markdown_it.utils import read_fixture_file
 import mdformat
+import pytest
+
+FIXTURE_PATH = Path(__file__).parent / "fixtures-semantic-indent.md"
+fixtures = read_fixture_file(FIXTURE_PATH)
 
 
-def test_align_semantic_breaks_in_numbered_lists():
-    """For https://github.com/KyleKing/mdformat-mkdocs/issues/4."""
-    input_text = """\
-1. Here indent width is
-   three.
-
-      2. Here indent width is
-       three.
-
-123. Here indent width is
-     five. It needs to be so, because
-
-     Otherwise this next paragraph doesn't belong in the same list item.
-"""
-    expected_output = """\
-1. Here indent width is
-   three.
-
-    1. Here indent width is
-       three.
-
-1. Here indent width is
-   five. It needs to be so, because
-
-   Otherwise this next paragraph doesn't belong in the same list item.
-"""
-
+@pytest.mark.parametrize(
+    "line,title,text,expected", fixtures, ids=[f[1] for f in fixtures]
+)
+def test_fixtures(line, title, text, expected):
     output = mdformat.text(
-        input_text,
+        text,
         options={"align_semantic_breaks_in_numbered_lists": True},
         extensions={"mkdocs"},
     )
-
-    assert output == expected_output
+    assert output.rstrip() == expected.rstrip()


### PR DESCRIPTION
Fixes #7

1. Add tests based on #6 and #7
1. Support 2-space on indents for nested bulleted lists to resolve #7