### PR TITLE
fix: non-semantic indents on code blocks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,7 +68,7 @@ jobs:
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python 3.8
         uses: actions/setup-python@v1
         with:
           python-version: 3.8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,12 @@ tox -e py37-hook
 Either use flit directly:
 
 ```bash
-pip install flit
+pipx install flit
+
+# envchain --set FLIT FLIT_PASSWORD
+export FLIT_USERNAME=__token__
+export eval $(envchain FLIT env | grep FLIT_PASSWORD=)
+
 flit publish
 ```
 

--- a/mdformat_mkdocs/__init__.py
+++ b/mdformat_mkdocs/__init__.py
@@ -1,6 +1,6 @@
 """An mdformat plugin for mkdocs."""
 
-__version__ = "1.0.3"
+__version__ = "1.0.4rc1"
 
 from .plugin import (  # noqa: F401
     POSTPROCESSORS,

--- a/mdformat_mkdocs/plugin.py
+++ b/mdformat_mkdocs/plugin.py
@@ -52,6 +52,7 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
     indent_counter = 0
     indent_lookup: Dict[str, int] = {}
     is_numbered = False
+    is_semantic_indent = False
     for line in text.split(eol):
         match = _RE_INDENT.match(line)
         assert match is not None  # for pylint
@@ -61,6 +62,9 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
             is_numbered = list_match["bullet"] not in {"-", "*"}
             new_bullet = "1." if is_numbered else "-"
             new_line = f'{new_bullet} {list_match["item"]}'
+            is_semantic_indent = True
+        elif not line:
+            is_semantic_indent = False  # on line break, use non-semantic indents
 
         this_indent = match["indent"]
         if this_indent:
@@ -78,7 +82,7 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
             indent_counter = 0
         last_indent = this_indent
         new_indent = indent * indent_counter
-        if _ALIGN_SEMANTIC_BREAKS_IN_LISTS and not list_match:
+        if _ALIGN_SEMANTIC_BREAKS_IN_LISTS and not list_match and is_semantic_indent:
             removed_indents = -1 if is_numbered else -2
             new_indent = new_indent[:removed_indents]
         rendered += f"{new_indent}{new_line.strip()}{eol}"

--- a/mkdocs-demo/docs/README.md
+++ b/mkdocs-demo/docs/README.md
@@ -6,22 +6,7 @@ Minimum example code to test MkDocs behavior
 
 See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
 
-### With proposed change
-
-1. Here indent width is
-   three.
-
-    1. Here indent width is
-       three.
-
-1. Here indent width is
-   five (three). The following indent needs to be four (but it is 3 with semantic change).
-
-   Otherwise this next paragraph doesn't belong in the same list item.
-
----
-
-### With current behavior
+### Default without Semantic Indents
 
 1. Here indent width is
     three (four).
@@ -34,18 +19,27 @@ See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
 
     Otherwise this next paragraph doesn't belong in the same list item.
 
----
+### With Smart Semantic Indents ON
 
-### With proposed change for bullets
+1. Here indent width is
+   three.
+
+    1. Here indent width is
+       three.
+
+1. Here indent width is
+   five (three). The following indent needs to be four (but it is 3 with semantic change).
+
+    Otherwise this next paragraph doesn't belong in the same list item.
+
+#### For bullets
 
 1. Line
    semantic line 1 (3 spaces deep)
     - Bullet (4 spaces deep)
       semantic line 2 (6 spaces deep)
 
----
-
-### With proposed change for bullets nested in a numbered list
+#### For bullets nested in a numbered list
 
 - Line
   semantic line 1 (2 spaces deep)

--- a/tests/fixtures-semantic-indent.md
+++ b/tests/fixtures-semantic-indent.md
@@ -140,7 +140,7 @@ List with (what should be converted to a) code block
 .
 - item 1
 
-  code block
+    code block
 .
 
 List with explicit code block (that should keep indentation)
@@ -153,9 +153,9 @@ List with explicit code block (that should keep indentation)
 .
 - item 1
 
-  ```txt
-  code block
-  ```
+    ```txt
+    code block
+    ```
 .
 
 
@@ -181,7 +181,7 @@ Hanging List (https://github.com/executablebooks/mdformat/issues/371 and https:/
 1. Here indent width is
    five. It needs to be so, because
 
-   Otherwise this next paragraph doesn't belong in the same list item.
+    Otherwise this next paragraph doesn't belong in the same list item.
 .
 
 
@@ -200,9 +200,9 @@ Code block in semantic indent (https://github.com/KyleKing/mdformat-mkdocs/issue
 1. Item 1
    with a semantic line feed
 
-   ```bash
-   echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
-   ```
+    ```bash
+    echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
+    ```
 
 1. Item 2
 

--- a/tests/pre-commit-test-align_semantic_breaks_in_lists.md
+++ b/tests/pre-commit-test-align_semantic_breaks_in_lists.md
@@ -13,7 +13,7 @@ See discussion on: https://github.com/KyleKing/mdformat-mkdocs/issues/4
 1. Here indent width is
    five (three). It needs to be so, because
 
-   Otherwise this next paragraph doesn't belong in the same list item.
+    Otherwise this next paragraph doesn't belong in the same list item.
 
 ## Code block in semantic indent
 
@@ -22,9 +22,9 @@ From: https://github.com/KyleKing/mdformat-mkdocs/issues/6
 1. Item 1
    with a semantic line feed
 
-   ```bash
-   echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
-   ```
+    ```bash
+    echo "I get moved around by prettier/mdformat, originally I am 3 spaces deep"
+    ```
 
 1. Item 2
 


### PR DESCRIPTION
Prototype implementation for non-semantic indents on code blocks to comply with `mkdocs` expectations. Fixes incorrect indents in mkdocs when a code block has less than a multiple of 4, which was previously demonstrated here, but is now fixed:

![Incorrect](https://github.com/KyleKing/mdformat-mkdocs/blob/46f07bc88f65f7fed6220943156db51dd82f1832/mkdocs-demo/mkdcs-demo-screenshot.png?raw=true)

Latest: https://github.com/KyleKing/mdformat-mkdocs/tree/46f07bc88f65f7fed6220943156db51dd82f1832/mkdocs-demo