### PR TITLE
hack: replicate word wrap issues

### DIFF
--- a/mdformat_mkdocs/__init__.py
+++ b/mdformat_mkdocs/__init__.py
@@ -1,6 +1,6 @@
 """An mdformat plugin for mkdocs."""
 
-__version__ = "1.0.4rc1"
+__version__ = "1.0.4rc2"
 
 from .plugin import (  # noqa: F401
     POSTPROCESSORS,

--- a/mdformat_mkdocs/plugin.py
+++ b/mdformat_mkdocs/plugin.py
@@ -1,6 +1,8 @@
 import argparse
+from contextlib import suppress
 import re
-from typing import Dict, Mapping
+import textwrap
+from typing import Dict, Mapping, Optional
 
 from markdown_it import MarkdownIt
 from mdformat.renderer import RenderContext, RenderTreeNode
@@ -17,6 +19,9 @@ _ALIGN_SEMANTIC_BREAKS_IN_LISTS = False
 
 """
 
+_MDFORMAT_WRAP: Optional[int] = None
+"""Paragraph word wrap mode (`{keep,no,INTEGER}`, default: `keep`)."""
+
 
 def add_cli_options(parser: argparse.ArgumentParser) -> None:
     """Add options to the mdformat CLI, to be stored in `mdit.options["mdformat"]`."""
@@ -29,10 +34,15 @@ def add_cli_options(parser: argparse.ArgumentParser) -> None:
 
 def update_mdit(mdit: MarkdownIt) -> None:
     """No changes to markdown parsing are necessary."""
-    global _ALIGN_SEMANTIC_BREAKS_IN_LISTS
+    global _ALIGN_SEMANTIC_BREAKS_IN_LISTS, _MDFORMAT_WRAP
+
     _ALIGN_SEMANTIC_BREAKS_IN_LISTS = mdit.options["mdformat"].get(
         "align_semantic_breaks_in_lists", False
     )
+
+    _wrap = mdit.options["mdformat"].get("wrap") or ""
+    with suppress(ValueError):
+        _MDFORMAT_WRAP = int(_wrap)
 
 
 _RE_INDENT = re.compile(r"(?P<indent>\s*)(?P<content>[^\s]?.*)")
@@ -42,6 +52,22 @@ _RE_LIST_ITEM = re.compile(r"(?P<bullet>[\-\*\d\.]+)\s+(?P<item>.+)")
 """Match `bullet` and `item` against `content`."""
 
 
+def _wrap_text(text: str, *, width: int) -> str:
+    """Wrap text.
+
+    Adapted from: https://github.com/executablebooks/mdformat/blob/0cbd2054dedf98ec8366001c8a16eacfa85cebc1/src/mdformat/renderer/_context.py#L320C1-L340C62
+
+    """
+    wrapper = textwrap.TextWrapper(
+        break_long_words=False,
+        break_on_hyphens=False,
+        width=width,
+        expand_tabs=False,
+        replace_whitespace=False,
+    )
+    return wrapper.fill(text)
+
+
 def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> str:
     """Post-processor to normalize lists."""
     eol = "\n"
@@ -49,6 +75,8 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
 
     rendered = ""
     last_indent = ""
+    new_indent = ""
+    last_wrapped_text = ""
     indent_counter = 0
     indent_lookup: Dict[str, int] = {}
     is_numbered = False
@@ -81,7 +109,18 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
         if _ALIGN_SEMANTIC_BREAKS_IN_LISTS and not list_match:
             removed_indents = -1 if is_numbered else -2
             new_indent = new_indent[:removed_indents]
-        rendered += f"{new_indent}{new_line.strip()}{eol}"
+
+        new_text = f"{new_indent}{new_line.strip()}"
+        if _MDFORMAT_WRAP and len(new_text) > _MDFORMAT_WRAP:
+            wrapped_text = _wrap_text(text=new_text, width=_MDFORMAT_WRAP)
+            new_text, *extra = wrapped_text.split("\n")
+            last_wrapped_text = "".join(extra)
+        rendered += f"{new_text}{eol}"
+        if last_wrapped_text:
+            rendered += f"{new_indent}{last_wrapped_text}{eol}"
+            last_wrapped_text = ""
+    if last_wrapped_text:
+        rendered += f"{new_indent}{last_wrapped_text}{eol}"
     return rendered.rstrip()
 
 

--- a/mdformat_mkdocs/plugin.py
+++ b/mdformat_mkdocs/plugin.py
@@ -17,7 +17,10 @@ _ALIGN_SEMANTIC_BREAKS_IN_LISTS = False
 
 """
 
-FILLER = "𝕏" * (_MKDOCS_INDENT_COUNT - 2)  # `mdformat` default is two spaces
+FILLER_CHAR = "𝕏"
+"""A spacer that is inserted and then removed to ensure proper word wrap."""
+
+FILLER = FILLER_CHAR * (_MKDOCS_INDENT_COUNT - 2)  # `mdformat` default is two spaces
 """A spacer that is inserted and then removed to ensure proper word wrap."""
 
 
@@ -84,7 +87,7 @@ def _normalize_list(text: str, node: RenderTreeNode, context: RenderContext) -> 
         if _ALIGN_SEMANTIC_BREAKS_IN_LISTS and not list_match:
             removed_indents = -1 if is_numbered else -2
             new_indent = new_indent[:removed_indents]
-        # new_line = new_line.replace(f"{FILLER} ", '').replace(FILLER, '')
+        new_line = new_line.replace(f"{FILLER_CHAR} ", "").replace(FILLER_CHAR, "")
         rendered += f"{new_indent}{new_line.strip()}{eol}"
     return rendered.rstrip()
 
@@ -104,7 +107,7 @@ def _postprocess_inline(text: str, node: RenderTreeNode, context: RenderContext)
     wrap_mode = context.options["mdformat"]["wrap"]
     if (
         not isinstance(wrap_mode, int)
-        or text.startswith(FILLER)  # noqa: W503
+        or FILLER_CHAR in text  # noqa: W503
         or (node.parent and node.parent.type != "paragraph")  # noqa: W503
         or (node.parent.parent and node.parent.parent.type != "list_item")  # noqa: W503
     ):
@@ -120,6 +123,7 @@ def _postprocess_inline(text: str, node: RenderTreeNode, context: RenderContext)
     soft_break = "\x00"
     text = text.lstrip(soft_break).lstrip()
     filler = (FILLER * indent_count)[:-1] if indent_count else ""
+    newline_filler = filler + FILLER if indent_count else FILLER[:-1]
     if len(text) > wrap_mode:
         indent_length = _MKDOCS_INDENT_COUNT * indent_count
         wrapped_length = -123
@@ -130,7 +134,7 @@ def _postprocess_inline(text: str, node: RenderTreeNode, context: RenderContext)
                 words = [filler, word]
                 wrapped_length = indent_length + len(word)
             elif next_length > wrap_mode:
-                words += [word, filler]
+                words += [word, newline_filler]
                 wrapped_length = indent_length + len(word)
             else:
                 words.append(word)

--- a/tests/test_align_semantic_breaks_in_lists.py
+++ b/tests/test_align_semantic_breaks_in_lists.py
@@ -14,7 +14,7 @@ fixtures = read_fixture_file(FIXTURE_PATH)
 def test_align_semantic_breaks_in_lists(line, title, text, expected):
     output = mdformat.text(
         text,
-        options={"align_semantic_breaks_in_lists": True},
+        options={"align_semantic_breaks_in_lists": True, "wrap": "keep"},
         extensions={"mkdocs"},
     )
     assert output.rstrip() == expected.rstrip()

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -12,5 +12,5 @@ fixtures = read_fixture_file(FIXTURE_PATH)
     "line,title,text,expected", fixtures, ids=[f[1] for f in fixtures]
 )
 def test_fixtures(line, title, text, expected):
-    output = mdformat.text(text, extensions={"mkdocs"})
+    output = mdformat.text(text, extensions={"mkdocs"}, options={"wrap": "keep"})
     assert output.rstrip() == expected.rstrip()

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -26,19 +26,19 @@ CASE_1_FALSE_40 = """
     Test Testing Test Testing Test
     Testing
     - Test Testing Test Testing Test
-        Testing Test Testing Test
         Testing Test Testing Test Testing
         Test Testing Test Testing Test
-        Testing Test Testing
+        Testing Test Testing Test Testing
+        Test Testing
 
-1. Test Testing Test Testing Test Testing
-    Test Testing Test Testing Test
-    Testing
-1. Test Testing Test Testing Test Testing
-    Test Testing Test Testing Test
+1. Test Testing Test Testing Test
+    Testing Test Testing Test Testing
+    Test Testing
+1. Test Testing Test Testing Test
     Testing Test Testing Test Testing
     Test Testing Test Testing Test
-    Testing
+    Testing Test Testing Test Testing
+    Test Testing
 """
 
 CASE_1_FALSE_80 = """
@@ -57,19 +57,22 @@ CASE_1_TRUE_40 = """
 # Content
 
 - Test Testing Test Testing Test Testing
-  Test Testing Test Testing Test Testing
+  Test Testing Test Testing Test
+  Testing
     - Test Testing Test Testing Test
       Testing Test Testing Test Testing
       Test Testing Test Testing Test
       Testing Test Testing Test Testing
       Test Testing
 
-1. Test Testing Test Testing Test Testing
-   Test Testing Test Testing Test Testing
-1. Test Testing Test Testing Test Testing
-   Test Testing Test Testing Test Testing
-   Test Testing Test Testing Test Testing
-   Test Testing Test Testing
+1. Test Testing Test Testing Test
+   Testing Test Testing Test Testing
+   Test Testing
+1. Test Testing Test Testing Test
+   Testing Test Testing Test Testing
+   Test Testing Test Testing Test
+   Testing Test Testing Test Testing
+   Test Testing
 """
 
 CASE_1_TRUE_80 = """
@@ -106,4 +109,8 @@ def test_wrap(text: str, expected: str, align_lists: bool, wrap: int):
         options={"align_semantic_breaks_in_lists": align_lists, "wrap": wrap},
         extensions={"mkdocs"},
     )
+
+    print(output.strip())
+    print("-- Expected --")
+    print(expected.strip())
     assert output.strip() == expected.strip()

--- a/tests/test_wrap.py
+++ b/tests/test_wrap.py
@@ -1,0 +1,109 @@
+import mdformat
+import pytest
+
+# Note: indented text that starts with a number is parsed as the start of a numbered list
+
+CASE_1 = """
+# Content
+
+- Test Testing Test Testing Test Testing Test Testing Test Testing
+    Test Testing
+  - Test Testing Test Testing Test Testing Test Testing Test Testing
+      Test Testing Test Testing Test Testing Test Testing Test Testing
+      Test Testing
+
+1. Test Testing Test Testing Test Testing Test Testing Test Testing
+    Test Testing
+  1. Test Testing Test Testing Test Testing Test Testing Test Testing
+      Test Testing Test Testing Test Testing Test Testing Test Testing
+      Test Testing
+"""
+
+CASE_1_FALSE_40 = """
+# Content
+
+- Test Testing Test Testing Test Testing
+    Test Testing Test Testing Test
+    Testing
+    - Test Testing Test Testing Test
+        Testing Test Testing Test
+        Testing Test Testing Test Testing
+        Test Testing Test Testing Test
+        Testing Test Testing
+
+1. Test Testing Test Testing Test Testing
+    Test Testing Test Testing Test
+    Testing
+1. Test Testing Test Testing Test Testing
+    Test Testing Test Testing Test
+    Testing Test Testing Test Testing
+    Test Testing Test Testing Test
+    Testing
+"""
+
+CASE_1_FALSE_80 = """
+# Content
+
+- Test Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+    - Test Testing Test Testing Test Testing Test Testing Test Testing Test
+        Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+
+1. Test Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+1. Test Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+    Test Testing Test Testing Test Testing Test Testing Test Testing
+"""
+
+CASE_1_TRUE_40 = """
+# Content
+
+- Test Testing Test Testing Test Testing
+  Test Testing Test Testing Test Testing
+    - Test Testing Test Testing Test
+      Testing Test Testing Test Testing
+      Test Testing Test Testing Test
+      Testing Test Testing Test Testing
+      Test Testing
+
+1. Test Testing Test Testing Test Testing
+   Test Testing Test Testing Test Testing
+1. Test Testing Test Testing Test Testing
+   Test Testing Test Testing Test Testing
+   Test Testing Test Testing Test Testing
+   Test Testing Test Testing
+"""
+
+CASE_1_TRUE_80 = """
+# Content
+
+- Test Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+    - Test Testing Test Testing Test Testing Test Testing Test Testing Test
+      Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+
+1. Test Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+1. Test Testing Test Testing Test Testing Test Testing Test Testing Test Testing
+   Test Testing Test Testing Test Testing Test Testing Test Testing
+"""
+
+
+@pytest.mark.parametrize(
+    "text,expected,align_lists,wrap",
+    [
+        (CASE_1, CASE_1_FALSE_40, False, 40),
+        (CASE_1, CASE_1_FALSE_80, False, 80),
+        (CASE_1, CASE_1_TRUE_40, True, 40),
+        (CASE_1, CASE_1_TRUE_80, True, 80),
+    ],
+    ids=[
+        "CASE_1_FALSE_40",
+        "CASE_1_FALSE_80",
+        "CASE_1_TRUE_40",
+        "CASE_1_TRUE_80",
+    ],
+)
+def test_wrap(text: str, expected: str, align_lists: bool, wrap: int):
+    output = mdformat.text(
+        text,
+        options={"align_semantic_breaks_in_lists": align_lists, "wrap": wrap},
+        extensions={"mkdocs"},
+    )
+    assert output.strip() == expected.strip()


### PR DESCRIPTION
Relates to #9 

Because this plugin modifies the indent in post-processing, the rules for wrapped text don't apply. I need to consider manipulating pre-indent