### PR TITLE
fix(#24): respect ordered lists that start with `0.`

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Supports:
 
 - Indents are converted to 4-spaces instead of 2
     - *Note*: see caveats when using the optional Semantic Indents on numbered lists which may not be a full multiple of 4
-- List bullets are converted to dashes instead of `*`
+- Unordered list bullets are converted to dashes (`-`) instead of `*`
+- By default, ordered lists are standardized on a single digit (`1.` or `0.`) unless `--number` is specified, then `mdformat-mkdocs` will apply consecutive numbering to ordered lists [for consistency with `mdformat`](https://github.com/executablebooks/mdformat?tab=readme-ov-file#options)
+- standardized as all `1.` rather than incrementing
 - Admonitions (extends [`mdformat-admon`](https://pypi.org/project/mdformat-admon))
 - MKDocs-Material Content Tabs (<https://squidfunk.github.io/mkdocs-material/reference/content-tabs>)
     - Note: the markup (HTML) rendered by this plugin is sufficient for formatting but not for viewing in a browser. Please open an issue if you have a need to generate valid HTML.

--- a/mdformat_mkdocs/_normalize_list.py
+++ b/mdformat_mkdocs/_normalize_list.py
@@ -248,7 +248,11 @@ def format_new_content(line: LineResult, inc_numbers: bool, is_code: bool) -> st
         assert list_match is not None  # for pyright # noqa: S101
         new_bullet = "-"
         if line.parsed.syntax == Syntax.LIST_NUMBERED:
-            counter = len(line.prev_list_peers) + 1 if inc_numbers else 1
+            first_peer = (
+                line.prev_list_peers[0] if line.prev_list_peers else line.parsed
+            )
+            base_num = 0 if first_peer.content.startswith("0.") else 1
+            counter = len(line.prev_list_peers) + base_num if inc_numbers else base_num
             new_bullet = f"{counter}."
         new_content = f'{new_bullet} {list_match["item"]}'
 

--- a/tests/format/fixtures/text.md
+++ b/tests/format/fixtures/text.md
@@ -1495,3 +1495,10 @@ Ignore multiple empty lines within code blocks
     * Asterisk
     ```
 .
+
+0-indexed markdown list (https://github.com/KyleKing/mdformat-mkdocs/issues/24)
+.
+0. xyz
+.
+0. xyz
+.

--- a/tests/format/test_number.py
+++ b/tests/format/test_number.py
@@ -50,14 +50,21 @@ CASE_1_NUMBERED = """
 7. Seven
 """
 
+CASE_2 = """
+0. xyz
+1. abc
+"""
+
 
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
         (CASE_1, CASE_1_NUMBERED),
+        (CASE_2, CASE_2),
     ],
     ids=[
         "CASE_1_NUMBERED",
+        "CASE_2_NUMBERED",
     ],
 )
 def test_number(text: str, expected: str):


### PR DESCRIPTION
Resolves #24