### PR TITLE
fix(#63): indentation in nested mkdocs elements

### DIFF
--- a/mdformat_mkdocs/_normalize_list.py
+++ b/mdformat_mkdocs/_normalize_list.py
@@ -469,9 +469,14 @@ def normalize_list(
         str: formatted text
 
     """
-    if node.level > 1:
-        # Note: this function is called recursively,
-        #   so only process the top-level item
+    # Calculate the expected level for a top-level list in the current context
+    # Each definition body adds 2 to the level and 4 to indent_width
+    defbody_count = context.env.get("indent_width", 0) // 4
+    expected_top_level = defbody_count * 2
+
+    # Only process top-level lists (not nested within other lists)
+    # This function is called recursively, so we skip nested lists to avoid double-processing
+    if node.level > expected_top_level + 1:
         return _strip_filler(text)
 
     # Retrieve user-options

--- a/tests/format/test_wrap.py
+++ b/tests/format/test_wrap.py
@@ -245,13 +245,13 @@ DEF_LIST_WITH_NESTED_WRAP_EXPECTED = dedent(
     :   Definition starts with a paragraph, followed by an unordered list:
 
         - Foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar
-          foo bar foo bar foo bar foo bar.
-
-          - (3) bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar
             foo bar foo bar foo bar foo bar.
 
-            - foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo
-              bar (split) foo bar foo bar foo bar foo bar.
+            - (3) bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar
+                foo bar foo bar foo bar foo bar.
+
+                - foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo bar foo
+                    bar (split) foo bar foo bar foo bar foo bar.
     """,
 )
 
@@ -299,3 +299,43 @@ def test_definition_list_wrap_with_gfm():
     )
     print_text(output, DEF_LIST_WITH_NESTED_WRAP_EXPECTED)
     assert output == DEF_LIST_WITH_NESTED_WRAP_EXPECTED
+
+
+def test_definition_list_nested_indentation():
+    """Test that nested lists in definition bodies use 4-space increments.
+
+    This is a regression test for issue #63.
+    """
+    input_text = dedent(
+        """\
+        term
+
+        :   Definition with a list:
+
+            - First item
+                - Nested item
+                    - Deep nested item
+        """,
+    )
+    expected = dedent(
+        """\
+        term
+
+        :   Definition with a list:
+
+            - First item
+                - Nested item
+                    - Deep nested item
+        """,
+    )
+    output = mdformat.text(input_text, extensions={"mkdocs"})
+    print_text(output, expected)
+    assert output == expected
+
+    # Verify the indentation levels are multiples of 4
+    lines = output.split('\n')
+    for line in lines:
+        if line.strip().startswith('-'):
+            spaces = len(line) - len(line.lstrip())
+            # Spaces before '-' should be 4, 8, or 12 (multiples of 4)
+            assert spaces in [4, 8, 12], f"Expected 4/8/12 spaces, got {spaces} in: {repr(line)}"


### PR DESCRIPTION
Previously, nested lists within definition bodies were using 2-space increments instead of the expected 4-space increments. This was caused by the normalize_list function skipping processing for any list with level > 1, which incorrectly excluded lists inside definition bodies.

The fix accounts for definition body context by checking context.env["indent_width"] to determine the expected level for top-level lists in the current context. Each definition body adds 2 to the token level and 4 to indent_width, so we calculate the expected top-level and only skip nested lists relative to that level.

This ensures that:
- Lists in definition bodies maintain 4-space indentation
- Nested lists within those lists also use 4-space increments
- The behavior is consistent with mdformat-mkdocs' 4-space convention

Fixes #63
Related to #58 (partial fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure nested lists within definition bodies use 4-space increments by determining top-level via context indent width; update expectations and add regression test.
> 
> - **Formatter**:
>   - Update `normalize_list` to compute expected top-level from `context.env["indent_width"]` (def bodies add 2 levels / 4 spaces) and only skip lists deeper than that, ensuring 4-space increments for lists inside definition bodies.
> - **Tests**:
>   - Adjust `DEF_LIST_WITH_NESTED_WRAP_EXPECTED` in `tests/format/test_wrap.py` to match corrected indentation.
>   - Add `test_definition_list_nested_indentation` to validate 4-space increments for nested lists in definition bodies (including 4/8/12-space checks).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 03c0567ef9d8c50442d599ed4130295e781f17a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->