### PR TITLE
Resolve CI pipeline issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,10 @@ jobs:
         with:
           python-version: 3.12
       - name: Installation (deps and package)
+        run: |
+          pip install flit~=3.10.1
+          flit install --deps=production --pth-file
+      - name: Install prek
         uses: j178/prek-action@v1
         with:
           install-only: true


### PR DESCRIPTION
The prek-hook CI job was failing because mdformat_mkdocs wasn't installed before running prek with the test configuration. The .pre-commit-test.yaml uses local hooks that require the package to be installed.

This fix adds the package installation step (using flit) before the prek installation, matching the pattern used in the tests job.

Fixes: https://github.com/KyleKing/mdformat-mkdocs/actions/runs/19562228686